### PR TITLE
perf: register commands only needed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
-CLIENT_ID=
 TOKEN=

--- a/src/DiscordBot.ts
+++ b/src/DiscordBot.ts
@@ -12,18 +12,16 @@ export default abstract class DiscordBot implements Bot {
     Intents.FLAGS.GUILD_VOICE_STATES,
   ];
 
-  protected readonly clientId: string;
   protected readonly token: string;
   protected readonly discordApi: DiscordApi;
   protected readonly commandManager: CommandManager;
   protected readonly client: Client;
 
-  public constructor(clientId: string, token: string) {
-    this.clientId = clientId;
+  public constructor(token: string) {
     this.token = token;
     this.discordApi = new DiscordApi({ version: '9' }).setToken(token);
     this.client = new Client({ intents: this.intents });
-    this.commandManager = new CommandManager(this.clientId, this.discordApi);
+    this.commandManager = new CommandManager(this.client, this.discordApi);
   }
 
   public run() {

--- a/src/__loader__/App.ts
+++ b/src/__loader__/App.ts
@@ -2,6 +2,6 @@ import dotenv from 'dotenv';
 import TierDiscordBot from '@/TierDiscordBot';
 
 dotenv.config();
-const { CLIENT_ID, TOKEN } = process.env;
+const { TOKEN } = process.env;
 
-new TierDiscordBot(CLIENT_ID, TOKEN).run();
+new TierDiscordBot(TOKEN).run();

--- a/src/commands/CommandManager.ts
+++ b/src/commands/CommandManager.ts
@@ -1,27 +1,36 @@
 import { REST as DiscordApi } from '@discordjs/rest';
 import { Routes } from 'discord-api-types/v9';
-import { CommandInteraction } from 'discord.js';
+import { Client, CommandInteraction } from 'discord.js';
 import Command from '@/commands/Command';
 
 export default class CommandManager {
 
-  private readonly clientId: string;
+  private readonly client: Client;
   private readonly discordApi: DiscordApi;
 
   private readonly commandByLabel = new Map<string, Command>();
 
-  public constructor(clientId: string, discordApi: DiscordApi) {
-    this.clientId = clientId;
+  public constructor(client: Client, discordApi: DiscordApi) {
+    this.client = client;
     this.discordApi = discordApi;
   }
 
   public async register(commands: Command[]): Promise<void> {
     try {
-      const commandsInfo = commands.map((command) => command.getInfo());
+      const registeredCommandMap = await this.client.application.commands.fetch();
+      const registeredCommands = registeredCommandMap.map((command) => command.name);
 
-      await this.discordApi.put(
-        Routes.applicationCommands(this.clientId), { body: commandsInfo },
-      );
+      const applicationId = this.client.application.id;
+      const commandsInfo = commands
+        .map((command) => command.getInfo())
+        .filter((command) => !registeredCommands.includes(command.name));
+
+      if (commandsInfo.length !== 0) {
+        await this.discordApi.put(
+          Routes.applicationCommands(applicationId), { body: commandsInfo },
+        );
+        console.log(`Registered new ${commandsInfo.length} commands to Discord successfully`);
+      }
 
       commands.forEach((command) => {
         this.commandByLabel.set(command.getInfo().name, command);


### PR DESCRIPTION
### Fixes 
- fix `invalid interaction application command` when register global commands continuously

---

Discord community said about **`Invalid interaction application command`**:
- After updating a global command Discord prevents you from receiving stale data until the update rolled out
- Refresh your commandlist to receive the updated command and try again